### PR TITLE
Remove Activity from Back Stack on Sign In or Sign Out

### DIFF
--- a/android/app/src/main/java/com/google/codeu/chatme/view/login/LoginActivity.java
+++ b/android/app/src/main/java/com/google/codeu/chatme/view/login/LoginActivity.java
@@ -81,6 +81,7 @@ public class LoginActivity extends AppCompatActivity implements LoginView, View.
     public void openChatActivity() {
         Intent mIntent = new Intent(LoginActivity.this, TabsActivity.class);
         startActivity(mIntent);
+        finish();
     }
 
     public void showProgressDialog(int messsage) {

--- a/android/app/src/main/java/com/google/codeu/chatme/view/tabs/ProfileFragment.java
+++ b/android/app/src/main/java/com/google/codeu/chatme/view/tabs/ProfileFragment.java
@@ -106,6 +106,7 @@ public class ProfileFragment extends Fragment implements ProfileView, View.OnCli
     public void openLoginActivity() {
         Intent intent = new Intent(getActivity(), LoginActivity.class);
         startActivity(intent);
+        getActivity().finish();
     }
 
     @Override


### PR DESCRIPTION
This essentially closes `LoginActivity` and `TabsActivity` if a user signs in and signs out respectively. This avoids authentication bugs in the future.