### PR TITLE
Reusing UsersFragment to avoid code duplication

### DIFF
--- a/android/app/src/main/java/com/google/codeu/chatme/view/create/CreateConversationActivity.java
+++ b/android/app/src/main/java/com/google/codeu/chatme/view/create/CreateConversationActivity.java
@@ -1,15 +1,14 @@
 package com.google.codeu.chatme.view.create;
 
 import android.os.Bundle;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 
 import com.google.codeu.chatme.R;
 import com.google.codeu.chatme.common.view.BaseActivity;
-import com.google.codeu.chatme.view.adapter.UserListAdapter;
+import com.google.codeu.chatme.view.tabs.UsersFragment;
 
-public class CreateConversationActivity extends BaseActivity {
+public class CreateConversationActivity extends BaseActivity
+        implements UsersFragment.OnFragmentInteractionListener {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -18,13 +17,5 @@ public class CreateConversationActivity extends BaseActivity {
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-
-        RecyclerView rvUserList = (RecyclerView) this.findViewById(R.id.userList);
-        rvUserList.setLayoutManager(new LinearLayoutManager(this));
-
-        UserListAdapter userListAdapter = new UserListAdapter(this);
-        rvUserList.setAdapter(userListAdapter);
-
-        userListAdapter.loadUsers();
     }
 }

--- a/android/app/src/main/res/layout/activity_create_conversation.xml
+++ b/android/app/src/main/res/layout/activity_create_conversation.xml
@@ -18,8 +18,9 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/userList"
+    <fragment
+        android:id="@+id/usersFragment"
+        android:name="com.google.codeu.chatme.view.tabs.UsersFragment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
This PR reuses `UsersFragment` in `CreateConversationActivity` because the two essentially functions in the same way.